### PR TITLE
Allow chef 12 in runtime_dependency

### DIFF
--- a/chef-attribute-validator.gemspec
+++ b/chef-attribute-validator.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 
-  spec.add_runtime_dependency "chef", "~> 11.6"  # TODO: test with older chefs
+  spec.add_runtime_dependency "chef", ">= 11.6"  # TODO: test with older chefs
 end


### PR DESCRIPTION
I tested it with chef 12.0.3 and 12.2.1. There are no issues, it works.
